### PR TITLE
Increase metrics granularity to determine sessions switch

### DIFF
--- a/packages/tty/option.go
+++ b/packages/tty/option.go
@@ -12,7 +12,7 @@ import (
 	"github.com/x-qdo/qudosh/packages/ttyrec"
 )
 
-const MetricsInterval = 10 * time.Second
+const MetricsInterval = 1 * time.Second
 
 func makeTimestamp() int64 {
 	return time.Now().UnixNano() / int64(time.Microsecond)


### PR DESCRIPTION
If used do a session switch the worst scenario is when he did actions in both sessions within the same metrics interval. In that case the most active will win which isn't always the last one.

To reduce that probability and d not spend tons of time on refactoring we can increase resolution of a metrics to handle that case.

QDO-1304